### PR TITLE
support redis connections that has `return_buffers` set to true

### DIFF
--- a/lib/redis-store.js
+++ b/lib/redis-store.js
@@ -34,7 +34,7 @@ var RedisStore = function(options) {
         });
 
         // if this is new or has no expiry
-        if (replies[0] === 1 || replies[1] === -1) {
+        if (Number(replies[0]) === 1 || Number(replies[1]) === -1) {
           // then expire it after the timeout
           options.client.expire(rdskey, options.expiry);
         }


### PR DESCRIPTION
This module does not work on connections that has `return_buffers` set to true.  That is because all values are returned as buffers in that case.  This fix supports that as well as the normal mode